### PR TITLE
实在看不下去了，我觉得应该给一段时间上传图片，然后在传上来的图片里随机抽取

### DIFF
--- a/upload/.gitignore
+++ b/upload/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
现在新的图片都是秒传，不给人上传的机会
而且可以用控制台强刷图片，导致上传的图片完全可控（我承认我干了这事，而且我还用控制台刷了吐槽233333）
我做了一下修改，每两局之间给10秒钟上传图片（如果没上传齐就重新等待10秒），然后再开始

顺手修了以下问题：
上传图片期间数字还是会加
把图片文件名改成图片MD5，防止重复存储（以及前面的修改后，防止重复上传，刷被抽中的概率）
（传上来的文件名看起来像MD5，但其实是一串随机的。。。）

本人完全不会写前端，所以前端一切都没改，如果要加上传图片一类的提示，可以读取data.allowUpload的值
